### PR TITLE
Update pom property che-server.version to 2850a74-fabric8-ace569f

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 
   <properties>
     <arquillian.version>1.1.8.Final</arquillian.version>
-    <che-server.version>2850a74-fabric8-a30072d</che-server.version>
+    <che-server.version>2850a74-fabric8-ace569f</che-server.version>
     <fabric8.version>2.2.205</fabric8.version>
     <fabric8.maven.plugin.version>3.5.25</fabric8.maven.plugin.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
Includes fix for usernames with `'_'` char.