### PR TITLE
Fix che ws shouldn't restart from URL access

### DIFF
--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -95,7 +95,7 @@ spec:
             configMapKeyRef:
               key: "workspaces-memory-request"
               name: "che"
-        - name: "CHE_WORKSPACE_AUTO_START"
+        - name: "CHE_WORKSPACE_AUTO__START"
           valueFrom:
             configMapKeyRef:
               key: "enable-workspaces-autostart"


### PR DESCRIPTION
Fix https://github.com/redhat-developer/rh-che/issues/297
Was missing `_` in the property name