### PR TITLE
Decrease readinessProbe initDelay for earlier availability

### DIFF
--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -158,8 +158,8 @@ spec:
             path: /api/system/state
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 10
+          initialDelaySeconds: 15
+          timeoutSeconds: 60
         livenessProbe:
           httpGet:
             path: /api/system/state


### PR DESCRIPTION
Before: Che ready after ~2 min
After: Che ready after ~1 min 15sec

![che-probes-update](https://user-images.githubusercontent.com/606959/30876451-fd6bdf98-a2f6-11e7-9501-fa148f13c37f.gif)
