### PR TITLE
Fix for https://github.com/openshiftio/openshift.io/issues/1067

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -27,3 +27,6 @@ data:
   che-server-timeout-ms: "3600000"
   che-openshift-precreate-subpaths: "false"
   che-workspace-auto-snapshot: "false"
+  che-keycloak-auth-server-url: ${CHE_KEYCLOAK_AUTH__SERVER__URL}
+  che-keycloak-realm: ${CHE_KEYCLOAK_REALM}
+  che-keycloak-client-id: ${CHE_KEYCLOAK_CLIENT__ID}

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -150,6 +150,21 @@ spec:
             configMapKeyRef:
               key: "che-workspace-auto-snapshot"
               name: "che"
+        - name: "CHE_KEYCLOAK_AUTH__SERVER__URL"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-keycloak-auth-server-url"
+              name: "che"
+        - name: "CHE_KEYCLOAK_REALM"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-keycloak-realm"
+              name: "che"
+        - name: "CHE_KEYCLOAK_CLIENT__ID"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-keycloak-client-id"
+              name: "che"
         image: "registry.devshift.net/che/che:${che-server.version}"
         imagePullPolicy: "IfNotPresent"
         name: che

--- a/packages/fabric8-tenant-che/src/main/fabric8/template.yml
+++ b/packages/fabric8-tenant-che/src/main/fabric8/template.yml
@@ -12,3 +12,9 @@ parameters:
   value: https://sso.prod-preview.openshift.io/auth/realms/fabric8/broker/openshift-v3/token
 - name: KEYCLOAK_GITHUB_ENDPOINT
   value: https://auth.prod-preview.openshift.io/api/token?for=https://github.com
+- name: CHE_KEYCLOAK_AUTH__SERVER__URL
+  value: https://sso.prod-preview.openshift.io/auth
+- name: CHE_KEYCLOAK_REALM
+  value: fabric8
+- name: CHE_KEYCLOAK_CLIENT__ID
+  value: openshiftio-public


### PR DESCRIPTION
This adds the 3 keycloak-related settings to the `che` deployment and config map files, as well as default settings for pre-production into the fabric8 template. 

Signed-off-by: David Festal <dfestal@redhat.com>