### PR TITLE
[che-server] Tune OpenJDK JVM flags so as to use less memory.

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -20,7 +20,7 @@ data:
   keycloak-oso-endpoint: ${KEYCLOAK_OSO_ENDPOINT}
   keycloak-github-endpoint: ${KEYCLOAK_GITHUB_ENDPOINT}
   keycloak-disabled: "false"
-  che-server-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=600m -Xms256m"
+  che-server-java-opts: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -184,7 +184,7 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            memory: 600Mi
+            memory: 512Mi
           requests:
             memory: 256Mi
         ports:


### PR DESCRIPTION
- Set MaxRAMFraction=2 so that MaxHeapSize (or -Xmx)
  will get set to ~1/2 of the container limit. It's
  ~1/4 by default.
- Set -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
  -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
  -XX:AdaptiveSizePolicyWeight=90 *and* -Xms20m (a
  small value) so as to make the collector work
  well for small JVMs.
- Set -XX:+UnlockExperimentalVMOptions
  -XX:+UseCGroupMemoryLimitForHeap for the JVM to know
  to base the memory settings on the container limit.
  It's the better alternative of the old MaxRAM setting.
- Don't memory-map jar files: -Dsun.zip.disableMemoryMapping=true
  as this also shaves off some bytes RSS.
- Reduce the che-server container limit from 600MB to
  512MB as it runs fine with the lower limit given the
  above tunings.