### PR TITLE
[che-worspaces] Tune OpenJDK JVM flags so as to use less memory.

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -14,14 +14,15 @@ data:
   port: "8080"
   remote-debugging-enabled: "false"
   che-oauth-github-forceactivation: "true"
-  workspaces-memory-limit: "1900Mi"
-  workspaces-memory-request: "1100Mi"
+  workspaces-memory-limit: "1280Mi"
+  workspaces-memory-request: "1000Mi"
   enable-workspaces-autostart: "false"
   keycloak-oso-endpoint: ${KEYCLOAK_OSO_ENDPOINT}
   keycloak-github-endpoint: ${KEYCLOAK_GITHUB_ENDPOINT}
   keycloak-disabled: "false"
   che-server-java-opts: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
-  che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
+  che-workspaces-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+  che-workspaces-maven-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m -Xmx230m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"
   che-server-timeout-ms: "3600000"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -110,6 +110,11 @@ spec:
             configMapKeyRef:
               key: "che-workspaces-java-opts"
               name: "che"
+        - name: "CHE_WORKSPACE_MAVEN_OPTIONS"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-workspaces-maven-opts"
+              name: "che"
         - name: "CHE_OPENSHIFT_SECURE_ROUTES"
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
- Set CHE_WORKSPACE_MAVEN_OPTIONS so as to set -Xmx to a similar
  value the builders use, plus 20 percent. The builder use 32bit
  OpenJDK which roughly uses 20% less memory than 64 bit OpenJDK.
  Thus, 192 + 192 * 0.2 = 230. See
  https://github.com/fabric8io/fabric8-pipeline-library/pull/362/
- Set preferred GC options for small JVMs, don't memory map
  JAR files, and make the JVM use the CGroup container limit rather
  than the hosts physical memory which, together, reduce memory
  footprint of che workspaces by roughly 30% as determined by VmRSS.
- Reduce container memory limit to 1280Mi (from 1900Mi) since it
  continues to work fine with the above tunings in place. This
  equates roughly 30% less than without the tuning.