### PR TITLE
[che-server] Tune for 32bit JDK.

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -20,7 +20,7 @@ data:
   keycloak-oso-endpoint: ${KEYCLOAK_OSO_ENDPOINT}
   keycloak-github-endpoint: ${KEYCLOAK_GITHUB_ENDPOINT}
   keycloak-disabled: "false"
-  che-server-java-opts: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -184,9 +184,9 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            memory: 512Mi
+            memory: 300Mi
           requests:
-            memory: 256Mi
+            memory: 200Mi
         ports:
         - containerPort: 8080
           name: "http"


### PR DESCRIPTION
Remove MaxRAMFraction=2 since this would turn out
to be too little heap for a memory limit of 300MB (i.e. 150MB).
Explicitly set MaxHeapSize=256m instead.

Che server VmRSS shows up to be ~240 to ~250MB with 32bit
OpenJDK and other tunings in place. Thus, I've done the exercise
of trying to squeeze che-server into a 300MB limit which seems to
work.