### PR TITLE
Make the migration config map optional to avoid blocking POD creation

### DIFF
--- a/packages/fabric8-tenant-che-mt/src/main/fabric8/migration-job.yml
+++ b/packages/fabric8-tenant-che-mt/src/main/fabric8/migration-job.yml
@@ -35,26 +35,31 @@ spec:
             configMapKeyRef:
               key: cleanup-single-tenant
               name: migration
+              optional: true
         - name: CHE_MULTITENANT_SERVER
           valueFrom:
             configMapKeyRef:
               key: che-multitenant-server
               name: migration
+              optional: true
         - name: OSIO_TOKEN
           valueFrom:
             configMapKeyRef:
               key: osio-token
               name: migration
+              optional: true
         - name: IDENTITY_ID
           valueFrom:
             configMapKeyRef:
               key: identity-id
               name: migration
+              optional: true
         - name: REQUEST_ID
           valueFrom:
             configMapKeyRef:
               key: request-id
               name: migration
+              optional: true
         image: registry.devshift.net/fabric8-services/fabric8-tenant-che-migration:${che-migration.version}
         imagePullPolicy: "Always"
       restartPolicy: Never


### PR DESCRIPTION
Make the migration config map optional so that if a Job starts without a config map (in case of multiple
concurrent migration Jbo starts), it will simply skip the migration
without failing or blocking (but logging a warning though).

Signed-off-by: David Festal <dfestal@redhat.com>