### PR TITLE
Also add the requestId directly as a Job env variable

### DIFF
--- a/packages/fabric8-tenant-che-mt/src/main/fabric8/migration-job.yml
+++ b/packages/fabric8-tenant-che-mt/src/main/fabric8/migration-job.yml
@@ -60,6 +60,8 @@ spec:
               key: request-id
               name: migration
               optional: true
+        - name: JOB_REQUEST_ID
+          value: ${REQUEST_ID}
         image: registry.devshift.net/fabric8-services/fabric8-tenant-che-migration:${che-migration.version}
         imagePullPolicy: "Always"
       restartPolicy: Never


### PR DESCRIPTION
Also add the requestId directly as a Job env variable.
This allows comparing it with the config map request ID and skipping
jobs that were not created at the same time as the current config map.
