### PR TITLE
Revert "Update pom property fabric8.maven.plugin.version to 3.5.33"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <che-server.version>fe2bed6-fabric8-d8655d6</che-server.version>
     <che-migration.version>latest</che-migration.version>
     <fabric8.version>2.2.205</fabric8.version>
-    <fabric8.maven.plugin.version>3.5.33</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.5.32</fabric8.maven.plugin.version>
     <junit.version>4.12</junit.version>
     <maven.enforcer.plugin.version>1.4</maven.enforcer.plugin.version>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>


### PR DESCRIPTION
This is an alternative fix for https://github.com/openshiftio/openshift.io/issues/1448. The [original fix](https://github.com/fabric8-services/fabric8-tenant/pull/487) cannot be applied because Jenkins is still using an older version of fabric8-maven-plugin.