### PR TITLE
Downgrade pom property `fabric8.maven.plugin.version` to `3.5.32`

### DIFF
--- a/packages/fabric8-tenant-che-mt/pom.xml
+++ b/packages/fabric8-tenant-che-mt/pom.xml
@@ -36,7 +36,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
-        <version>${fabric8.maven.plugin.version}</version>
+        <version>3.5.33</version>
         <configuration>
           <enricher>
             <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,11 @@
     <che-server.version>fe2bed6-fabric8-d8655d6</che-server.version>
     <che-migration.version>latest</che-migration.version>
     <fabric8.version>2.2.205</fabric8.version>
-    <fabric8.maven.plugin.version>3.5.33</fabric8.maven.plugin.version>
+    <!-- Be careful, when upgrading fabric8.maven.plugin.version here,
+     to also update the one in packages/fabric8-tenant-che-mt/pom.xml
+     that is currently overridden due to a limitation of the
+     3.5.32 version -->
+    <fabric8.maven.plugin.version>3.5.32</fabric8.maven.plugin.version>
     <junit.version>4.12</junit.version>
     <maven.enforcer.plugin.version>1.4</maven.enforcer.plugin.version>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>


### PR DESCRIPTION
Downgrade pom property `fabric8.maven.plugin.version` to `3.5.32` to keep old api version numbers on deployments, except for the `packages/fabric8-tenant-che-mt/pom.xml` that would stay in `3.5.33`
since `3.5.32` doesn't support optional environment variables based on
config maps, and this is required for the migration Job.

Signed-off-by: David Festal <dfestal@redhat.com>