### PR TITLE
Revert "Downgrade pom property `fabric8.maven.plugin.version`

### DIFF
--- a/packages/fabric8-tenant-che-mt/pom.xml
+++ b/packages/fabric8-tenant-che-mt/pom.xml
@@ -36,7 +36,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
-        <version>3.5.33</version>
+        <version>${fabric8.maven.plugin.version}</version>
         <configuration>
           <enricher>
             <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,7 @@
     <che-server.version>fe2bed6-fabric8-d8655d6</che-server.version>
     <che-migration.version>latest</che-migration.version>
     <fabric8.version>2.2.205</fabric8.version>
-    <!-- Be careful, when upgrading fabric8.maven.plugin.version here,
-     to also update the one in packages/fabric8-tenant-che-mt/pom.xml
-     that is currently overridden due to a limitation of the
-     3.5.32 version -->
-    <fabric8.maven.plugin.version>3.5.32</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.5.33</fabric8.maven.plugin.version>
     <junit.version>4.12</junit.version>
     <maven.enforcer.plugin.version>1.4</maven.enforcer.plugin.version>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>


### PR DESCRIPTION
This reverts commit 09bc72f882b4ba84b00004c963242089776eacf9. 

This is now needed because Jenkins has been upgraded to version https://github.com/fabric8-services/fabric8-tenant/commit/d8b5febc77ea099ac5995e98831f45678dc889f0 and uses `fabric8.maven.plugin.version` `3.5.32` (c.f. this [SEV1 in production](https://github.com/fabric8-services/fabric8-tenant-che/pull/89))

Once this PR is merged we need to merge https://github.com/fabric8-services/fabric8-tenant/pull/487 too.