### PR TITLE
Adjusted memory limit, charset encoding and threshold

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -20,7 +20,7 @@ data:
   keycloak-oso-endpoint: ${KEYCLOAK_OSO_ENDPOINT}
   keycloak-github-endpoint: ${KEYCLOAK_GITHUB_ENDPOINT}
   keycloak-disabled: "false"
-  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m"
+  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"
@@ -30,4 +30,4 @@ data:
   che-keycloak-auth-server-url: ${CHE_KEYCLOAK_AUTH__SERVER__URL}
   che-keycloak-realm: ${CHE_KEYCLOAK_REALM}
   che-keycloak-client-id: ${CHE_KEYCLOAK_CLIENT__ID}
-  che-wsagent-ping-success-threshold: "25"
+  che-wsagent-ping-success-threshold: "2"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -189,7 +189,7 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            memory: 300Mi
+            memory: 600Mi
           requests:
             memory: 200Mi
         ports:


### PR DESCRIPTION
- memory limit: with 300Mi wsmaster was particularly slow, we set it back to 600Mi
- charset encoding: using 32 bit jdk had as a consequence that UTF-8 wasn't used as Charset anymore (we spotted a lot of `java.nio.charset.MalformedInputException: Input length = 1”?` in the logs). Adding `-Dfile.encoding=UTF8` to the `che-server-java-opts` fixes that.
- wsagent ping success threshold: we set that back to 2 because it looks like the flapping problem has been resolved once OpenShift v3.7 has been deployed on osio