### PR TITLE
rh-che #532: Adding che SA to 'fabric8-tenant-che-mt'

### DIFF
--- a/packages/fabric8-tenant-che-mt/src/main/fabric8/sa-rb.yml
+++ b/packages/fabric8-tenant-che-mt/src/main/fabric8/sa-rb.yml
@@ -1,0 +1,7 @@
+metadata:
+  name: che
+roleRef:
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: che

--- a/packages/fabric8-tenant-che-mt/src/main/fabric8/sa.yml
+++ b/packages/fabric8-tenant-che-mt/src/main/fabric8/sa.yml
@@ -1,0 +1,2 @@
+metadata:
+  name: che


### PR DESCRIPTION
Adding che SA with admin role binding to `fabric8-tenant-che-mt` template:

```
- apiVersion: v1
  kind: ServiceAccount
  metadata:
    labels:
      app: fabric8-tenant-che-mt
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: che
- apiVersion: v1
  kind: RoleBinding
  metadata:
    labels:
      app: fabric8-tenant-che-mt
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: che
  roleRef:
    name: admin
  subjects:
  - kind: ServiceAccount
    name: che
```

This SA will be used by oso proxy for resource creation in `*-che` namespaces