### PR TITLE
rh-che #675 Changes in che tenant quotas required for increasing memory limits to 3GB for workspace pods

### DIFF
--- a/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/compute-resources-rq.yml
+++ b/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/compute-resources-rq.yml
@@ -4,7 +4,7 @@ metadata:
   name: compute-resources
 spec:
   hard:
-    limits.cpu: "5"
-    limits.memory: 2.5Gi
+    limits.cpu: "6"
+    limits.memory: 3Gi
   scopes:
   - NotTerminating

--- a/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/compute-resources-timebound-rq.yml
+++ b/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/compute-resources-timebound-rq.yml
@@ -4,7 +4,7 @@ metadata:
   name: compute-resources-timebound
 spec:
   hard:
-    limits.cpu: "4"
-    limits.memory: 2.5Gi
+    limits.cpu: "6"
+    limits.memory: 3Gi
   scopes:
   - Terminating

--- a/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/limitrange.yml
+++ b/packages/fabric8-tenant-che-quotas-oso/src/main/fabric8/limitrange.yml
@@ -5,8 +5,8 @@ metadata:
 spec:
   limits:
   - max:
-      cpu: "4880m"
-      memory: "2.5Gi"
+      cpu: "6000m"
+      memory: "3Gi"
     min:
       cpu: "29m"
       memory: "150Mi"
@@ -18,8 +18,8 @@ spec:
       cpu: 60m
       memory: 307Mi
     max:
-      cpu: "4880m"
-      memory: 2.5Gi
+      cpu: "6000m"
+      memory: 3Gi
     min:
       cpu: 29m
       memory: 150Mi


### PR DESCRIPTION
Related issue - https://github.com/redhat-developer/rh-che/issues/675

New quotas are expected to be the following once PR is merged

![image](https://user-images.githubusercontent.com/1461122/42640125-e5ddad5a-85f1-11e8-82e6-e1e143a5046e.png)


Resulting quota yml:

```
---
apiVersion: v1
kind: List
items:
- apiVersion: v1
  kind: LimitRange
  metadata:
    labels:
      app: fabric8-tenant-che-quotas-oso
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: resource-limits
  spec:
    limits:
    - max:
        cpu: 6000m
        memory: 3Gi
      min:
        cpu: 29m
        memory: 150Mi
      type: Pod
    - default:
        cpu: "1"
        memory: 512Mi
      defaultRequest:
        cpu: 60m
        memory: 307Mi
      max:
        cpu: 6000m
        memory: 3Gi
      min:
        cpu: 29m
        memory: 150Mi
      type: Container
    - max:
        storage: 1Gi
      min:
        storage: 1Gi
      type: PersistentVolumeClaim
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    labels:
      app: fabric8-tenant-che-quotas-oso
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: compute-resources
  spec:
    hard:
      limits.cpu: "6"
      limits.memory: 3Gi
    scopes:
    - NotTerminating
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    labels:
      app: fabric8-tenant-che-quotas-oso
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: compute-resources-timebound
  spec:
    hard:
      limits.cpu: "6"
      limits.memory: 3Gi
    scopes:
    - Terminating
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    labels:
      app: fabric8-tenant-che-quotas-oso
      provider: fabric8
      version: 2.0.0-SNAPSHOT
      group: io.fabric8.tenant.packages
    name: object-counts
  spec:
    hard:
      persistentvolumeclaims: "2"
      replicationcontrollers: "20"
      secrets: "20"
      services: "5"

```