### PR TITLE
Adapt to changes to mavenCI step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ releaseNode {
 
     if (utils.isCI()) {
 
-      def version = mavenCI{}
+      def version = mavenCI{ goal = "deploy" }
       // hard coded for now
       def mvnRepo = "https://nexus.cd.test.fabric8.io/content/repositories/staging"
       def message = "PR now available for testing: https://openshift.io/_profile/_tenant?cheVersion=${version}&mavenRepo=${mvnRepo}"


### PR DESCRIPTION
Recently a change was introduced to mavenCI step which runs `install`
goal instead of `deploy`, this breaks testing PR as artifacts won't be
uploaded to nexus.

This patch fixes the issue by overriding the goal to `deploy`.

For details about the changes to mavenCI and mavenCanaryRelease
See: https://github.com/fabric8io/fabric8-pipeline-library/pull/418