### PR TITLE
[WIP] Adding exec RoleBinding to user

### DIFF
--- a/packages/fabric8-tenant-che-mt/src/main/fabric8/user-exec-rb.yml
+++ b/packages/fabric8-tenant-che-mt/src/main/fabric8/user-exec-rb.yml
@@ -1,0 +1,9 @@
+metadata:
+  name: user-exec
+roleRef:
+  name: exec
+subjects:
+- kind: User
+  name: ${PROJECT_USER}
+userNames:
+- ${PROJECT_USER}


### PR DESCRIPTION
Before applying this PR, HK issue should be created in order to request corresponding `exec` role  required to *-che tenant e.g.: 

```
apiVersion: v1
kind: Role
metadata:
  name: exec
rules:
- apiGroups:
  - ""
  attributeRestrictions: null
  resources:
  - pods/exec
  verbs:
  - create
```
