### PR TITLE
chore: add readme info about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# WARNING: This project has been deprecated
+
+The template management has been moved directly to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant) repository. Any additional changes in the templates should be done in the repo and not here.
+Files that were originally managed/produced by this repo can be found here:
+
+* [fabric8-tenant-che.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-che.yml)
+* [fabric8-tenant-che-mt.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-che-mt.yml)
+* [fabric8-tenant-che-quotas.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-che-quotas.yml)
+
 # fabric8-tenant-che
 
 To test YAML changes on PR see https://github.com/fabric8-services/fabric8-tenant#testing-yaml


### PR DESCRIPTION
This PR adds a README info about the project deprecation ([PR](https://github.com/fabric8-services/fabric8-tenant/pull/634) that moves templates to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant/) repo has been merged)